### PR TITLE
Structure Flask app with blueprint support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,16 @@
+import os
+from flask import Flask
+
+
+def create_app():
+    """Application factory for the Flask app."""
+    template_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+    static_dir = os.path.join(os.path.dirname(__file__), "..", "static")
+
+    app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
+    app.config.from_object("app.config.Config")
+
+    from .routes import main_bp
+    app.register_blueprint(main_bp)
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,6 @@
+import os
+
+
+class Config:
+    """Base configuration."""
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev")

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, render_template
+
+
+main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/")
+def index():
+    return render_template("index.html")


### PR DESCRIPTION
## Summary
- add entrypoint app.py to run Flask app
- initialize app package with configuration and blueprint registration
- provide main blueprint rendering index template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9b3c9748832285cb842411eb7451