### PR TITLE
Integrate SQLAlchemy and add initial database schema

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,9 @@
 import os
 from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
 
 
 def create_app():
@@ -9,6 +13,7 @@ def create_app():
 
     app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
     app.config.from_object("app.config.Config")
+    db.init_app(app)
 
     from .routes import main_bp
     app.register_blueprint(main_bp)

--- a/app/config.py
+++ b/app/config.py
@@ -4,3 +4,8 @@ import os
 class Config:
     """Base configuration."""
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URI",
+        "mysql+pymysql://user:password@localhost/todo_db",
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/modelo.sql
+++ b/modelo.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS tasks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    content VARCHAR(255) NOT NULL,
+    end_date DATE,
+    category VARCHAR(50),
+    completed BOOLEAN DEFAULT FALSE
+);


### PR DESCRIPTION
## Summary
- configure SQLAlchemy connection settings and disable modification tracking
- initialize a global SQLAlchemy instance within the Flask factory
- define an initial tasks table schema in `modelo.sql`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c039b5610832297ec8fc055dd8dd0